### PR TITLE
Update init.sh/software-properties-common package no longer needed

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -30,7 +30,7 @@ echo ""
 echo "Docker installation"
 export DEBIAN_FRONTEND=noninteractive 
 apt update && apt upgrade -y
-apt-get -y install ca-certificates software-properties-common screen ipset vim strace rsyslog git apache2-utils
+apt-get -y install ca-certificates screen ipset vim strace rsyslog git apache2-utils
 install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
 chmod a+r /etc/apt/keyrings/docker.asc


### PR DESCRIPTION
The software-properties-common package, which provides the add-apt-repository command for managing software sources, was removed from Debian 13 (Trixie) because the functionality is being replaced by the newer debian.sources file format and APT tools.