### PR TITLE
Remove COMPOSER_MEMORY_LIMIT from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,6 @@ x-php_args: &php_args
 #  Configure php env variables
 # -----------------------------------------------------------------------------------------------------------------------
 x-php_env: &php_env
-  COMPOSER_MEMORY_LIMIT:
   MARIADB_DATABASE:
   MARIADB_USER:
   MARIADB_PASSWORD:


### PR DESCRIPTION
Removed COMPOSER_MEMORY_LIMIT from PHP environment variables.