### PR TITLE
Remove MariaDB config volume from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,6 @@ services:
       - /run/mariadb:uid=${MARIADB_UID},gid=${MARIADB_UID},mode=0700
     volumes:
       - ${CONTAINER_DATA_PATH}/mariadb:/var/lib/mysql
-      - ./mariadb/config:/etc/mysql/conf.d:ro
     user: "${MARIADB_UID}:${MARIADB_UID}"
     restart: unless-stopped
     healthcheck:


### PR DESCRIPTION
Removed the configuration volume for MariaDB.